### PR TITLE
Use NSFoundationVersionNumber for iOS 8 detection

### DIFF
--- a/Swift Weather/ViewController.swift
+++ b/Swift Weather/ViewController.swift
@@ -219,13 +219,13 @@ class ViewController: UIViewController, CLLocationManagerDelegate {
     /*
     iOS 8 Utility
     */
-    func ios8() -> Bool {
+2    func ios8() -> Bool {
         println("iOS " + UIDevice.currentDevice().systemVersion)
         // There is a problem if Apple upgrades iOS version to 8.1 or something else.
-        if ( UIDevice.currentDevice().systemVersion == "8.0" ) {
-            return true
-        } else {
+        if ( NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_7_1 ) {
             return false
+        } else {
+            return true
         }
     }
     


### PR DESCRIPTION
NSFoundationVersionNumber can be used to check the version of iOS, so when later versions of iOS 8 are released the detection will still work.
