### PR TITLE
Use NSFoundationVersionNumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SwiftWeather
 ============
 
-SwiftWeather is a small iOS app developed by Swift language.
+SwiftWeather is a small iOS app developed in Swift language.
 
 ##Screenshots
 ![Loading](https://raw.githubusercontent.com/JakeLin/SwiftWeather/master/screenshots/loading-33.png)

--- a/Swift Weather/ViewController.swift
+++ b/Swift Weather/ViewController.swift
@@ -219,13 +219,13 @@ class ViewController: UIViewController, CLLocationManagerDelegate {
     /*
     iOS 8 Utility
     */
-    func ios8() -> Bool {
+2    func ios8() -> Bool {
         println("iOS " + UIDevice.currentDevice().systemVersion)
         // There is a problem if Apple upgrades iOS version to 8.1 or something else.
-        if ( UIDevice.currentDevice().systemVersion == "8.0" ) {
-            return true
-        } else {
+        if ( NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_7_1 ) {
             return false
+        } else {
+            return true
         }
     }
     


### PR DESCRIPTION
NSFoundationVersionNumber can be used to check the version of iOS, so
when later versions of iOS 8 are released the detection will still work.
