### PR TITLE
add appid for openweather

### DIFF
--- a/SwiftWeather/OpenWeatherMapService.swift
+++ b/SwiftWeather/OpenWeatherMapService.swift
@@ -95,7 +95,9 @@ struct OpenWeatherMapService : WeatherServiceProtocol {
     }
     
     components.queryItems = [NSURLQueryItem(name:"lat", value:String(location.coordinate.latitude)),
-                             NSURLQueryItem(name:"lon", value:String(location.coordinate.longitude))]
+                             NSURLQueryItem(name:"lon", value:String(location.coordinate.longitude)),
+                             NSURLQueryItem(name:"appid", value:String("bd82977b86bf27fb59a04b61b657fb6f"))]
+                             //Please sign up for openweather( http://openweathermap.org/appid ) and put your own appid here.
     return components.URL
   }
 }


### PR DESCRIPTION
Hi, thanks so much for your nice work!  : ) 
I am testing the project on my local machine. Everything works fine but it could not return the desired JSON data.....
Looks like the API of OpenWeather has been changed. It requires appid right now. (http://api.openweathermap.org/data/2.5/weather?lat=35&lon=139&appid=bd82977b86bf27fb59a04b61b657fb6f) Otherwise, it will trigger a 401 error. (http://api.openweathermap.org/data/2.5/weather?lat=35&lon=139)