### PR TITLE
Update rename to change the project name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
-Swift Weather
+Swift Language Weather
 ============
 [![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=562a9aac2492560100211378&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/562a9aac2492560100211378/build/latest)
 ![Language](https://img.shields.io/badge/language-Swift%204-orange.svg)
 ![License](https://img.shields.io/github/license/JakeLin/SwiftWeather.svg?style=flat)
 
-SwiftWeather is an iOS weather app developed in Swift 4. The app has been actively upgrading to adopt the latest features of iOS and Swift language.
+**SwiftWeather** has renamed to **Swift Language Weather**. Because this repo is ranked number one in Google when we search "Swift Weather", I got an email from Swift Weather Company's lawyer to ask me to change the name because they said they are the owner of U.S. Trademark SWIFT WEATHER. After discussed with them, they were not happy with the name Swift**y**Weather. Now the new project name is **Swift Language Weather**. More details can be found on [Issue: Open source project using a registered trademark](https://github.com/JakeLin/SwiftWeather/issues/65).
+
+**Swift Language Weather** is an iOS weather app developed in Swift 4. The app has been actively upgrading to adopt the latest features of iOS and Swift language.
 
 ## Notices
-The current version is working with Xcode Version 9. If you are using different Xcode version, please check out the previous releases. 
+The current version is working with Xcode Version Xcode 9.1 (9B55). If you are using different Xcode version, please check out the previous releases. 
 
 ## Version 4
 This version has been upgraded to support iOS 10+ only using Swift 4.
 
-There is three major version for the app released before.
+There is three major version of the app released before.
 
 * V1.0 - Support iOS 7+ using CocoaPods and AFNetworking. [README.v1.md](https://github.com/JakeLin/SwiftWeather/blob/master/README.v1.md) and [Release V1 - Using CocoaPods and AFNetworking](https://github.com/JakeLin/SwiftWeather/releases/tag/V1)
 * V2.0 - Support iOS 8+ using Carthage, Alamofire, and SwiftyJSON. [README.v2.md](https://github.com/JakeLin/SwiftWeather/blob/master/README.v2.md) and [Release V2.0](https://github.com/JakeLin/SwiftWeather/releases/tag/v2.0)
@@ -24,8 +26,8 @@ There is three major version for the app released before.
 
 
 ## Features
-* Swift Programming Language - fully upgraded to version 2
-* Design driven development - [Sketch design file ](https://raw.githubusercontent.com/JakeLin/SwiftWeather/master/Design/SwiftWeather.sketch)
+* Swift Programming Language
+* Design-driven development - [Sketch design file ](https://raw.githubusercontent.com/JakeLin/SwiftWeather/master/Design/SwiftWeather.sketch)
 
 ![Sketch design](https://raw.githubusercontent.com/JakeLin/SwiftWeather/master/screenshots/SketchDesign.png)
  
@@ -46,8 +48,8 @@ There is three major version for the app released before.
 ![Size Classes](https://raw.githubusercontent.com/JakeLin/SwiftWeather/master/screenshots/UIStackView-with-Size-Classes.png)
 
 * MVVM - Reactively update `ViewController` UI from `ViewModel`
-* Protocol-Oriented Programming - Still learning though and finding the best practice of that.
-* Value based programming - Use imutable value anywhere.
+* Protocol-Oriented Programming - We use Protocol-Oriented Programming in [IBAnimatable open source project](https://github.com/IBAnimatable/IBAnimatable).
+* Value-based programming - Use immutable value anywhere.
 * Icon fonts － Use [Weather Icons](https://erikflowers.github.io/weather-icons/)
 * [SwiftyJSON](https://github.com/SwiftyJSON/SwiftyJSON)
 * Core Location
@@ -61,13 +63,13 @@ There is three major version for the app released before.
 1) Clone the repository
 
 ```bash
-$ git clone https://github.com/JakeLin/SwiftWeather.git
+$ git clone https://github.com/JakeLin/SwiftLanguageWeather.git
 ```
 
 2) Install pods
 
 ```bash
-$ cd SwiftWeather
+$ cd SwiftLanguageWeather
 $ pod install
 ```
 


### PR DESCRIPTION
Because of a registered trademark issue, we change the project name from **SwiftWeather** to **Swift Language Weather**. More details can be found on #65 